### PR TITLE
Fixed authentication

### DIFF
--- a/varnish.py
+++ b/varnish.py
@@ -110,7 +110,7 @@ class VarnishHandler(Telnet):
 
     def auth(self, secret, content):
         challenge = content[:32]
-        response = sha256('%s\n%s\n%s\n' % (challenge, secret, challenge))
+        response = sha256('%s\n%s%s\n' % (challenge, secret, challenge))
         response_str = 'auth %s' % response.hexdigest()
         self.fetch(response_str)
 


### PR DESCRIPTION
That newline character was causing the authentication to fail. More info is available here: https://www.varnish-cache.org/trac/wiki/CLI

Thanks!