### PR TITLE
Two PURGE issues addressed

### DIFF
--- a/varnish.py
+++ b/varnish.py
@@ -51,8 +51,9 @@ def http_purge_url(url):
     """
     url = urlparse(url)
     connection = HTTPConnection(url.hostname, url.port or 80)
-    connection.request('PURGE', '%s?%s' % (url.path or '/', url.query), '',
-                      {'Host': url.hostname})
+    path = url.path or '/'
+    connection.request('PURGE', '%s?%s' % (path, url.query) if url.query else path, '',
+                       {'Host': '%s:%s' % (url.hostname, url.port) if url.port else url.hostname})
     response = connection.getresponse()
     if response.status != 200:
         logging.error('Purge failed with status: %s' % response.status)


### PR DESCRIPTION
I found that PURGE calls were failing for two reasons/scenarios:

1. '?' was *always* appended to the URL to purge, which caused misses in the lookup, and resulted in purging not happening for the requested URL.
2. when running your website with a port specified (ie. http://localhost:8002/), the Host header in the purge call incorrectly does not include the port. This too caused misses in the Varnish lookup and results in no purge happening.