### PR TITLE
example incorrect

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Example::
 
   manager = VarnishManager( ('server1:6082', 'server2:6082') )
   manager.run('ping')
-  manager.run('ban.url ^/secret/$')
+  manager.run('ban.url', '^/secret/$')
   manager.run('ban.list')
   manager.run('purge.url', 'http://mydomain.com/articles/.*')
   manager.close()


### PR DESCRIPTION
The example for ban.url shows the arguments as one string `manager.run('ban.url ^/secret/$')`: 'ban.url ^/secret/$'

But this only seems to work when broken into two arguments: "ban.url" and "^/secret/$"

`manager.run('ban.url', '^/secret/$')`