### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ Example::
 
   manager = VarnishManager( ('server1:6082', 'server2:6082') )
   manager.run('ping')
-  manager.run('ban.url ^/secret/$')
+  manager.run('ban.url', '^/secret/$')
   manager.run('ban.list')
   manager.run('purge.url', 'http://mydomain.com/articles/.*')
   manager.close()


### PR DESCRIPTION
Example for ban.url is wrong, it expects an argument like the purge.url example.
